### PR TITLE
bumped npm version, added utils to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 node_modules/
 src/
 linting/
+utils/
 .babelrc
 .eslintignore
 .gitignore

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "paw",
     "paw-core"
   ],
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "index.js",
   "license": "MIT",
   "homepage": "https://github.com/luckymarmot/Paw-BaseImporter",


### PR DESCRIPTION
Correct way to publish to npm is now

```
make publish
```

as it transpiles the `src` into `lib`
